### PR TITLE
Add a function that directly converts a Write to a ByteString

### DIFF
--- a/Blaze/ByteString/Builder.hs
+++ b/Blaze/ByteString/Builder.hs
@@ -79,6 +79,7 @@ module Blaze.ByteString.Builder
     , fromWrite
     , fromWriteSingleton
     , fromWriteList
+    , writeToByteString
 
     -- ** Writing 'Storable's
     , writeStorable


### PR DESCRIPTION
This function is useful when you want to efficiently construct a short, fixed-sized bytestring.
