### PR TITLE
Expose the Buffer constructor.

### DIFF
--- a/Blaze/ByteString/Builder/Internal/Buffer.hs
+++ b/Blaze/ByteString/Builder/Internal/Buffer.hs
@@ -18,7 +18,7 @@
 --
 module Blaze.ByteString.Builder.Internal.Buffer (
   -- * Buffers
-    Buffer
+    Buffer (..)
 
   -- ** Status information
   , freeSize


### PR DESCRIPTION
This is necessary for an optimization in Warp, where we already have a
pool of raw buffers available which I'd like to reuse for blaze-builder.
Relevant issue: https://github.com/yesodweb/wai/issues/198
