### PR TITLE
Remove check for APPLICATIVE_IN_BASE cpp def

### DIFF
--- a/Blaze/ByteString/Builder/Internal/Types.hs
+++ b/Blaze/ByteString/Builder/Internal/Types.hs
@@ -19,9 +19,7 @@
 --
 module Blaze.ByteString.Builder.Internal.Types where
 
-#ifdef APPLICATIVE_IN_BASE
 import Control.Applicative
-#endif
 
 import Data.Monoid
 import qualified Data.ByteString      as S
@@ -86,7 +84,6 @@ instance Functor Put where
   fmap f (Put put) = Put $ \k -> put (\x -> k (f x))
   {-# INLINE fmap #-}
 
-#ifdef APPLICATIVE_IN_BASE
 instance Applicative Put where
   pure x = Put $ \k -> k x
   {-# INLINE pure #-}
@@ -96,7 +93,6 @@ instance Applicative Put where
   {-# INLINE (<*) #-}
   a *> b = Put $ \k -> unPut a (\_ -> unPut b k)
   {-# INLINE (*>) #-}
-#endif
 
 instance Monad Put where
   return x = Put $ \k -> k x

--- a/benchmarks/Throughput/BlazePutMonad.hs
+++ b/benchmarks/Throughput/BlazePutMonad.hs
@@ -59,9 +59,7 @@ import Data.Word
 import qualified Data.ByteString      as S
 import qualified Data.ByteString.Lazy as L
 
-#ifdef APPLICATIVE_IN_BASE
 import Control.Applicative
-#endif
 
 
 ------------------------------------------------------------------------
@@ -82,14 +80,12 @@ instance Functor PutM where
         fmap f m = Put $ let PairS a w = unPut m in PairS (f a) w
         {-# INLINE fmap #-}
 
-#ifdef APPLICATIVE_IN_BASE
 instance Applicative PutM where
         pure    = return
         m <*> k = Put $
             let PairS f w  = unPut m
                 PairS x w' = unPut k
             in PairS (f x) (w `mappend` w')
-#endif
 
 -- Standard Writer monad, with aggressive inlining
 instance Monad PutM where


### PR DESCRIPTION
As we currently depend on base == 4.*, there's no need to check whether
Control.Applicative is provided in base -- it has been since base 2.x.

Furthermore, as far as I can tell, the APPLICATIVE_IN_BASE preprocessor
variable wasn't even being set anywhere, so the #ifdef directives
actually hid the code blocks inside them in all cases, not only when
base was sufficiently new.

This commit makes Applicative-Monad proposal -related warnings from GHC
7.8 go away.
