### PR TITLE
Bump text upper version bounds

### DIFF
--- a/blaze-builder.cabal
+++ b/blaze-builder.cabal
@@ -75,4 +75,4 @@ Library
   
   build-depends:     base == 4.* ,
                      bytestring >= 0.9 && < 1.0 ,
-                     text >= 0.10 && < 1.2
+                     text >= 0.10 && < 1.3


### PR DESCRIPTION
Allow `blaze-builder` to use `text-1.2.0.0`
